### PR TITLE
Resolving issues with entries being duplicated

### DIFF
--- a/lib/identity_entry_box/identity_entry_box.viewmodel.dart
+++ b/lib/identity_entry_box/identity_entry_box.viewmodel.dart
@@ -9,7 +9,7 @@ class IdentityEntryBoxViewModel extends ComponentBaseModel {
   late IlocalStorage _storage;
   final KeyDto keyData;
   late String _name;
-  late String _email;
+  bool _isSaving = false;
 
   IdentityEntryBoxViewModel(super.context, this.keyData) {
     _identityManager = getIt.get<IIdentityManager>();
@@ -21,8 +21,11 @@ class IdentityEntryBoxViewModel extends ComponentBaseModel {
   }
 
   Future onSave() async {
-    var id = await _storage.generateId();
+    if (_isSaving) return;
 
+    _isSaving = true;
+
+    var id = await _storage.generateId();
     var result = await _identityManager.setSecret(
       StoredIdentity(
         id,

--- a/lib/password_entry_box/password_entry_box.viewmodel.dart
+++ b/lib/password_entry_box/password_entry_box.viewmodel.dart
@@ -30,6 +30,7 @@ class PasswordEntryBoxViewModel extends ComponentBaseModel {
   bool get isUnique => _isUnique;
   bool _isCopyActionPresent = false;
   bool get isCopyActionPresent => _isCopyActionPresent;
+  bool _isSaving = false;
 
   PasswordEntryBoxViewModel(super.context) {
     _secretManager = getIt.get<ISecretManager>();
@@ -51,6 +52,9 @@ class PasswordEntryBoxViewModel extends ComponentBaseModel {
   }
 
   Future onSave() async {
+    if (_isSaving) return;
+
+    _isSaving = true;
     var id = await _storage.generateId();
     var result = await _secretManager.setSecret(
       StoredSecret(


### PR DESCRIPTION
Both for the identity and password box, it's possible to duplicate entries by being really quick with the button press. 

Adding a check to ensure that only one save can occur